### PR TITLE
BAH-4163 | Add. Field for ADBM Identifier in users table

### DIFF
--- a/src/main/resources/liquibase.xml
+++ b/src/main/resources/liquibase.xml
@@ -508,4 +508,19 @@
         <modifyDataType tableName="health_information" columnName="doc_id" newDataType="varchar(128)"/>
     </changeSet>
 
+    <changeSet id="202402111552" author="Mohan,Dev,Arshiya">
+        <preConditions>
+            <tableExists tableName="user"/>
+            <not>
+                <columnExists tableName="user" columnName="hpin"/>
+            </not>
+        </preConditions>
+        <comment>Add hpin column to user table</comment>
+        <addColumn tableName="user">
+            <column name="hpin" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/liquibase.xml
+++ b/src/main/resources/liquibase.xml
@@ -508,8 +508,8 @@
         <modifyDataType tableName="health_information" columnName="doc_id" newDataType="varchar(128)"/>
     </changeSet>
 
-    <changeSet id="202402111552" author="Mohan,Dev,Arshiya">
-        <preConditions>
+    <changeSet id="202402111552" author="Mohan_Dev_Arshiya">
+        <preConditions onFail="MARK_RAN">
             <tableExists tableName="user"/>
             <not>
                 <columnExists tableName="user" columnName="hpin"/>


### PR DESCRIPTION
This PR extends the `user` table of health_information_user database to add a column for storing the `Health Practitioner Identifier issued by NDHM`. This identifier will be used while creating a consent request as a requester identifier.